### PR TITLE
feat: Add deployment script and vaultwarden integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
+.env.bootstrap
 db.env
 .idea

--- a/README.md
+++ b/README.md
@@ -32,50 +32,86 @@ To receive notifications on your mobile device, install the `ntfy` app:
 Once installed, add your self-hosted server in the app settings to start receiving notifications from your stack.
 
 # Usage
-1. Clone this repository
-2. Create a .env file with following content:
-```bash
-COMPOSE_PROJECT_NAME=nextcloud
-MYSQL_ROOT_PASSWORD={YOUR_SECRET_ROOT_PASSWORD}
-DNS_ADDRESS={YOUR_DNS_ADDRESS}
-VAULTWARDEN_PREFIX={YOUR_VAULTWARDEN_SUBDOMAIN}
-VAULTWARDEN_ADMIN_TOKEN={YOUR_VAULTWARDEN_ADMIN_TOKEN}
-NEXTCLOUD_PREFIX={YOUR_NEXTCLOUD_SUBDOMAIN}
-LETSENCRYPT_EMAIL={YOUR_EMAIL_ADDRESS}
-TZ={YOUR_TIMEZONE}  # cat /etc/timezone
-BORG_PASSPHRASE={YOUR_SECURE_BORG_PASSWORD} # encrypts your backups, useful to upload the archive to services like AWS Glacier
-VOLUME_TARGET={PATH_TO_YOUR_BACKUP_FOLDER}
-NTFY_PREFIX={YOUR_NTFY_SUBDOMAIN}
-NTFY_TOPIC={YOUR_NTFY_TOPIC}
-NTFY_TOKEN={YOUR_NTFY_ACCESS_TOKEN}
 
-# Check https://rclone.org/docs/#configure or your cloud provider documentation
-RCLONE_CONFIG_NEXTCLOUD_TYPE=
-RCLONE_CONFIG_NEXTCLOUD_PROVIDER=
-RCLONE_CONFIG_NEXTCLOUD_ACL=
-RCLONE_CONFIG_NEXTCLOUD_ACCESS_KEY_ID=
-RCLONE_CONFIG_NEXTCLOUD_SECRET_ACCESS_KEY=
-RCLONE_CONFIG_NEXTCLOUD_ENDPOINT=
-```
-3. Create a db.env file with following content:
-```bash
-MYSQL_PASSWORD={YOUR_SECRET_USER_PASSWORD}
-MYSQL_USER={YOUR_SQL_USER_NAME}
+## 1. Secret Management (Vaultwarden)
+This stack is designed to be deployed securely using your local **Vaultwarden** (via `rbw`). Instead of keeping sensitive `.env` files on your server, create a single item in your vault (e.g., named `.env` in a "Nextcloud stack" folder) and add all your variables to its **Note** field in `KEY=VALUE` format:
+
+```text
+COMPOSE_PROJECT_NAME=nextcloud
+MYSQL_ROOT_PASSWORD=...
 MYSQL_DATABASE=nextcloud
+MYSQL_USER=nextcloud
+MYSQL_PASSWORD=...
+DNS_ADDRESS=...
+VAULTWARDEN_PREFIX=...
+NEXTCLOUD_PREFIX=...
+LETSENCRYPT_EMAIL=...
+TZ=...
+BORG_PASSPHRASE=...
+VOLUME_TARGET=...
+NTFY_PREFIX=...
+NTFY_TOPIC=...
+NTFY_TOKEN=...
+
+# rclone config
+RCLONE_CONFIG_NEXTCLOUD_TYPE=...
+...
 ```
-4. Start or update stack with 
-```
-docker-compose build --pull
-docker-compose up -d
-```
-5. Initialize the borg repository
+
+## 2. Deploy the Stack
+Use the provided `deploy.sh` script to sync your files and inject secrets from your vault directly into the remote server's memory.
+
 ```bash
-docker exec nextcloud_borgmatic_backup_1 sh -c "borgmatic --init --encryption repokey-blake2"
+# Unlock your local vault first
+rbw unlock
+
+# Run the deployment script
+./deploy.sh \
+  --user your_ssh_user \
+  --host your_server_ip \
+  --path ~/nextcloud-stack \
+  --item .env \
+  --folder "Nextcloud stack"
 ```
-6. Export borg repo key (to your backup folder)
-```bash
-docker exec nextcloud_borgmatic_backup_1 sh -c "borg key export /mnt/borg-repository /mnt/borg-repository/key-export.txt"
-```
+
+The script will:
+1. Fetch secrets from your local `rbw`.
+2. Sync the stack files to your remote server via `rsync`.
+3. Pull the latest images.
+4. Rebuild custom images (like backup/proxy) with the latest patches.
+5. Start/Restart the containers with the injected secrets.
+
+## 3. Initializing the Stack
+If this is a fresh installation:
+1. Initialize the borg repository:
+   ```bash
+   ssh your_ssh_user@your_server_ip "cd ~/nextcloud-stack && docker compose exec borgmatic_backup borgmatic --init --encryption repokey-blake2"
+   ```
+2. Export the borg repo key:
+   ```bash
+   ssh your_ssh_user@your_server_ip "cd ~/nextcloud-stack && docker compose exec borgmatic_backup borg key export /mnt/borg-repository /mnt/borg-repository/key-export.txt"
+   ```
+
+## 4. First Time Setup (Bootstrap)
+If you are deploying this stack for the very first time (and don't have a Vaultwarden account yet):
+
+1.  **Run in New Mode:**
+    ```bash
+    ./deploy.sh --user your_user --host your_ip --path ~/nextcloud-stack --new
+    ```
+    Enter your desired passwords and config when prompted.
+2.  **Create Vaultwarden Account:**
+    Once the stack is up, go to `https://vault.yourdomain.com` and register your account.
+3.  **Connect rbw Locally:**
+    ```bash
+    rbw config set base_url https://vault.yourdomain.com
+    rbw login
+    ```
+4.  **Migrate Secrets:**
+    Create a new item in your vault named `.env` and paste the variables you used in step 1 into the **Notes** field.
+5.  **Future Deploys:**
+    From now on, you can just use the standard command without the `--new` flag.
+
 # Backups
 The stack will automatically back up your running nextlcoud instance with the help of [borg](https://borgbackup.readthedocs.io/en/stable/index.html)/[borgmatic](https://torsion.org/borgmatic/). Per default, it will create a new backup every day at 1am. If you want to change this, adapt the [crontab.txt](https://github.com/fezu54/nextcloud-stack/blob/main/backup/borgmatic.d/crontab.txt) in this repository.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Default values
+REMOTE_USER=""
+REMOTE_HOST=""
+REMOTE_PATH=""
+VAULT_ITEM=""
+VAULT_FOLDER=""
+NEW_DEPLOYMENT=false
+
+# List of essential variables to prompt for in --new mode
+REQUIRED_VARS=(
+    "MYSQL_ROOT_PASSWORD"
+    "MYSQL_DATABASE"
+    "MYSQL_USER"
+    "MYSQL_PASSWORD"
+    "DNS_ADDRESS"
+    "NEXTCLOUD_PREFIX"
+    "VAULTWARDEN_PREFIX"
+    "LETSENCRYPT_EMAIL"
+    "TZ"
+    "BORG_PASSPHRASE"
+    "VOLUME_TARGET"
+    "NTFY_PREFIX"
+    "NTFY_TOPIC"
+    "NTFY_TOKEN"
+    "FRESH_RSS_PREFIX"
+    "FRESH_RSS_DB_PASSWORD"
+)
+
+# Function to check local dependencies
+check_dependencies() {
+    local deps=("rsync" "ssh")
+    [ "$NEW_DEPLOYMENT" = false ] && deps+=("rbw")
+
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            echo "❌ Error: Required tool '$dep' is not installed locally."
+            exit 1
+        fi
+    done
+}
+
+# Function to show usage
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Required Options:"
+    echo "  -u, --user     Remote SSH username"
+    echo "  -h, --host     Remote host IP or hostname"
+    echo "  -p, --path     Remote directory path for the stack"
+    echo "  -i, --item     Vaultwarden item name (ignored if --new is used)"
+    echo ""
+    echo "Optional Options:"
+    echo "  -n, --new      New deployment mode (interactive prompts, skip rbw)"
+    echo "  -f, --folder   Vaultwarden folder name"
+    echo "  --help         Show this help message"
+    echo ""
+    echo "Example (Standard):"
+    echo "  $0 -u john -h 1.2.3.4 -p ~/stack -i .env"
+    echo ""
+    echo "Example (New Deployment):"
+    echo "  $0 -u john -h 1.2.3.4 -p ~/stack --new"
+    exit 1
+}
+
+# Parse named arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -u|--user)   REMOTE_USER="$2";   shift 2 ;;
+        -h|--host)   REMOTE_HOST="$2";   shift 2 ;;
+        -p|--path)   REMOTE_PATH="$2";   shift 2 ;;
+        -i|--item)   VAULT_ITEM="$2";    shift 2 ;;
+        -f|--folder) VAULT_FOLDER="$2";  shift 2 ;;
+        -n|--new)    NEW_DEPLOYMENT=true; shift 1 ;;
+        --help)      usage ;;
+        *)           echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# Validate required arguments
+if [ -z "$REMOTE_USER" ] || [ -z "$REMOTE_HOST" ] || [ -z "$REMOTE_PATH" ] || { [ "$NEW_DEPLOYMENT" = false ] && [ -z "$VAULT_ITEM" ]; }; then
+    echo "❌ Error: Missing required arguments."
+    usage
+fi
+
+# Check for local tools
+check_dependencies
+
+VAULT_SECRETS=""
+
+if [ "$NEW_DEPLOYMENT" = true ]; then
+    echo "🆕 NEW DEPLOYMENT MODE"
+    echo "Please enter the values for your environment variables (input is hidden):"
+    
+    BOOTSTRAP_FILE=".env.bootstrap"
+    echo "# Generated during bootstrap on $(date)" > "$BOOTSTRAP_FILE"
+    chmod 600 "$BOOTSTRAP_FILE"
+
+    for var in "${REQUIRED_VARS[@]}"; do
+        read -rsp "Enter value for $var: " val
+        echo " (captured)"
+        # 1. For the remote command (escaped for shell)
+        VAULT_SECRETS="$VAULT_SECRETS $var='$val'"
+        # 2. For the local bootstrap file (raw KEY=VALUE)
+        echo "$var=$val" >> "$BOOTSTRAP_FILE"
+    done
+    echo ""
+    echo "📝 All variables have been saved to local file: $BOOTSTRAP_FILE"
+    echo "   You can use this file to copy-paste your secrets into Vaultwarden later."
+else
+    echo "🔍 Checking local Vault (rbw)..."
+    
+    # 1. Construct rbw command
+    RBW_CMD="rbw get"
+    if [ -n "$VAULT_FOLDER" ]; then
+        RBW_CMD="$RBW_CMD --folder \"$VAULT_FOLDER\""
+        echo "📂 Folder: $VAULT_FOLDER"
+    fi
+    RBW_CMD="$RBW_CMD \"$VAULT_ITEM\""
+    echo "🔑 Item:   $VAULT_ITEM"
+
+    # 2. Try to fetch secrets from rbw
+    if rbw unlock --check >/dev/null 2>&1; then
+        echo "🔓 Vault is unlocked. Fetching secrets..."
+        
+        # Execute the constructed rbw command
+        VAULT_SECRETS=$(eval "$RBW_CMD" 2>/dev/null | grep '=' | tr '\n' ' ')
+        
+        if [ -n "$VAULT_SECRETS" ]; then
+            echo "✅ Secrets retrieved from vault."
+        else
+            echo "⚠️ Could not find or read '$VAULT_ITEM' (Folder: ${VAULT_FOLDER:-None})."
+            echo "   Exiting."
+            exit 1
+        fi
+    else
+        echo "❌ rbw is locked or not configured. (Run 'rbw unlock' first or use --new mode)"
+        exit 1
+    fi
+fi
+
+# 3. Sync local files to remote
+echo "Syncing files to $REMOTE_HOST:$REMOTE_PATH..."
+rsync -avz \
+    --exclude='.git*' \
+    --exclude='.env' \
+    --exclude='db.env' \
+    --exclude='deploy.sh' \
+    ./ "$REMOTE_USER@$REMOTE_HOST:$REMOTE_PATH/"
+
+# 4. Construct and execute the remote command
+# We prepend the secrets to each command to ensure they are available
+REMOTE_CMD="cd $REMOTE_PATH && \
+            $VAULT_SECRETS docker compose pull && \
+            $VAULT_SECRETS docker compose build --pull && \
+            $VAULT_SECRETS docker compose up -d --remove-orphans"
+
+echo "🚀 Deploying and updating on remote server..."
+ssh -t "$REMOTE_USER@$REMOTE_HOST" "$REMOTE_CMD"

--- a/deploy.sh
+++ b/deploy.sh
@@ -143,9 +143,8 @@ fi
 # 3. Sync local files to remote
 echo "Syncing files to $REMOTE_HOST:$REMOTE_PATH..."
 rsync -avz \
-    --exclude='.git*' \
-    --exclude='.env' \
-    --exclude='db.env' \
+    --filter=':- .gitignore' \
+    --exclude='.git' \
     --exclude='deploy.sh' \
     ./ "$REMOTE_USER@$REMOTE_HOST:$REMOTE_PATH/"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -121,7 +121,7 @@ else
     echo "🔑 Item:   $VAULT_ITEM"
 
     # 2. Try to fetch secrets from rbw
-    if rbw unlock --check >/dev/null 2>&1; then
+    if rbw unlock >/dev/null 2>&1; then
         echo "🔓 Vault is unlocked. Fetching secrets..."
         
         # Execute the constructed rbw command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,11 @@ services:
       - db:/var/lib/mysql
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MARIADB_AUTO_UPGRADE=1
       - MARIADB_DISABLE_UPGRADE_BACKUP=1
-    env_file:
-      - db.env
     networks: 
       - backups
 
@@ -33,8 +34,10 @@ services:
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
       - MYSQL_HOST=db
       - REDIS_HOST=redis
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
     env_file:
-      - db.env
       - php.env
     depends_on:
       - db


### PR DESCRIPTION
This commit introduces a new deploy.sh script to streamline remote deployments by syncing files via rsync and injecting secrets directly from Vaultwarden using rbw. It also updates the docker-compose.yml to use environment variables for database configuration instead of a local db.env file, enhancing security and secret management. The README.md has been overhauled to reflect this new deployment workflow.